### PR TITLE
Allows connection to daemonized vw

### DIFF
--- a/test/test_wabbit_wappa.py
+++ b/test/test_wabbit_wappa.py
@@ -137,3 +137,12 @@ def test_training():
         vw.close()
         vw2.close()
         os.remove(filename)
+
+
+def test_daemons():
+    # Launch one VW in daemon_mode
+    vw = VW(loss_function='logistic', daemon_mode=True, port=30000)
+    # Connect to that one without launching another
+    vw2 = VW(daemon_ip='127.0.0.1', port=30000)
+
+

--- a/wabbit_wappa/active_learner.py
+++ b/wabbit_wappa/active_learner.py
@@ -25,7 +25,7 @@ MAX_CONNECTION_ATTEMPTS = 50
 
 
 def get_active_default_settings():
-    result = dict(active_learning=True,
+    result = dict(active=True,
                   port=DEFAULT_PORT,
                   predictions='/dev/null',
                   )

--- a/wabbit_wappa/active_learner.py
+++ b/wabbit_wappa/active_learner.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 """
 Interface for VW's active learning mode, which must be communicated with
-over a socked.
+over a socket.
 
 Derived in great part from
 https://github.com/JohnLangford/vowpal_wabbit/blob/master/utl/active_interactor.py
@@ -13,11 +13,13 @@ by Michael J.T. O'Kelly, 2014-04-11
 
 import socket
 import time
+import logging
 
 import pexpect
 
 
 DEFAULT_PORT = 26542
+DEFAULT_IP = '127.0.0.1'
 CONNECTION_WAIT = 0.1  # Time between socket connection attempts
 MAX_CONNECTION_ATTEMPTS = 50
 
@@ -30,30 +32,46 @@ def get_active_default_settings():
     return result
 
 
-class ActiveVWProcess():
-    """Class for spawning and interacting with a WV process
-    in active learning mode.  This class implements a subset of the interface
+class DaemonVWProcess():
+    """Class for spawning and/or interacting with a WV process
+    in daemon mode.  This class implements a subset of the interface
     of a pexpect.spawn() object so that it can be a drop-in replacement
     for the VW.vw_process member.
     """
 
     _buffer = b''
 
-    def __init__(self, command, port=DEFAULT_PORT):
+    def __init__(self, command=None, port=None, ip=None):
         """'command' is assumed to have the necessary options for use with this
-        class, which should be guaranteed in the calling context."""
-        # Launch the VW process, which we will communicate with only
-        # via its socket
-        self.vw_process = pexpect.spawn(command)
+        class (such as a consistent value for `port`),
+        which should be guaranteed in the calling context.
+
+        If 'command' is not given, or if 'ip' is given, assume that a
+            daemonized VW process has already been launched, and attach
+            to it with the given ip and port."""
+        if command and not ip:
+            # Launch the VW process, which we will communicate with only
+            # via its socket
+            self.vw_process = pexpect.spawn(command)
+            logging.info("Started VW({})".format(command))
+        else:
+            self.vw_process = None
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         connection_tries = 0
         while connection_tries < MAX_CONNECTION_ATTEMPTS:
             try:
-                self.sock.connect(('127.0.0.1', port))
+                if not ip:
+                    ip = DEFAULT_IP
+                if not port:
+                    port = DEFAULT_PORT
+                self.sock.connect((ip, port))
+                logging.info("Connected to VW daemon ({}:{})".format(ip, port))
                 break  # Quit this loop once successful
             except socket.error:
                 connection_tries += 1
                 time.sleep(CONNECTION_WAIT)
+        else:
+            raise
         self.before = None
 
     def sendline(self, line):
@@ -89,6 +107,7 @@ class ActiveVWProcess():
 
     def close(self):
         self.sock.close()
-        self.vw_process.close()
+        if self.vw_process:
+            self.vw_process.close()
 
 

--- a/wabbit_wappa/active_learner.py
+++ b/wabbit_wappa/active_learner.py
@@ -46,10 +46,10 @@ class DaemonVWProcess():
         class (such as a consistent value for `port`),
         which should be guaranteed in the calling context.
 
-        If 'command' is not given, or if 'ip' is given, assume that a
+        If 'command' is not given, assume that a
             daemonized VW process has already been launched, and attach
             to it with the given ip and port."""
-        if command and not ip:
+        if command:
             # Launch the VW process, which we will communicate with only
             # via its socket
             self.vw_process = pexpect.spawn(command)


### PR DESCRIPTION
This PR primarily allows connections to a deamonized vw if an ip and port are only given. The current repo also has an older name for the active learning parameter, `active_learning` instead of `active` that causes it to fail under newer versions of VW.